### PR TITLE
Add Arkansas to list of allowed Kaltura oembed providers

### DIFF
--- a/pressbooks_kaltura_oembed.php
+++ b/pressbooks_kaltura_oembed.php
@@ -16,4 +16,5 @@ function kaltura_add_oembed_handlers(){
     wp_oembed_add_provider( 'https://media.kpu.ca/*', 'https://media.kpu.ca/oembed/' );
     wp_oembed_add_provider( 'https://iu.mediaspace.kaltura.com/*', 'https://iu.mediaspace.kaltura.com/oembed', false );
     wp_oembed_add_provider( 'https://learning.kaltura.com/*', 'https://learning.kaltura.com/oembed', false );
+    wp_oembed_add_provider( 'https://video.uark.edu/*', 'https://video.uark.edu/oembed', false );
 }


### PR DESCRIPTION
Fix for https://github.com/pressbooks/pressbooks-kaltura-oembed/issues/1. This PR adds the University of Arkansas' Kaltura MediaSpace instance to the list of oembed providers registered with WordPress/Pressbooks. Once merged, it should allow users from Arkansas to paste oembed links to their videos in Pressbooks and have them automatically converted to iframes.